### PR TITLE
Make config_dir OS agnostic

### DIFF
--- a/keepasshttp/session.py
+++ b/keepasshttp/session.py
@@ -20,7 +20,7 @@ class Session(object):
     @classmethod
     def start(cls, appname):
         """Start a new communication session."""
-        config_dir = os.path.join(os.getenv('HOME'), '.config/', appname)
+        config_dir = os.path.join(os.path.expanduser("~"), '.config/', appname)
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir, 0o700)
         config_path = os.path.join(config_dir, 'keepasshttp.json')


### PR DESCRIPTION
Windows (or at least my windows 10 machine) does not have the 'HOME' environment variable, but Python is able to expand the '~' symbol correctly on it's own: https://stackoverflow.com/a/4028943